### PR TITLE
Add 'number' input to width and height

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -244,11 +244,19 @@ document.addEventListener("DOMContentLoaded", () => {
         toggleState = null;
     };
     tileWidthInput.addEventListener("input", () => {
-        tileWidthValue.textContent = tileWidthInput.value;
+        tileWidthValue.value = tileWidthInput.value;
         generateGrid();
     });
     tileHeightInput.addEventListener("input", () => {
-        tileHeightValue.textContent = tileHeightInput.value;
+        tileHeightValue.value = tileHeightInput.value;
+        generateGrid();
+    });
+    tileWidthValue.addEventListener("input", () => {
+        tileWidthInput.value = tileWidthValue.value;
+        generateGrid();
+    });
+    tileHeightValue.addEventListener("input", () => {
+        tileHeightInput.value = tileHeightValue.value;
         generateGrid();
     });
     scaleInput.addEventListener("input", () => {
@@ -802,8 +810,8 @@ document.addEventListener("DOMContentLoaded", () => {
         const scale = decoder.getScale();
         tileWidthInput.value = tileWidth.toString();
         tileHeightInput.value = tileHeight.toString();
-        tileWidthValue.textContent = tileWidthInput.value;
-        tileHeightValue.textContent = tileHeightInput.value;
+        tileWidthValue.value = tileWidthInput.value;
+        tileHeightValue.value = tileHeightInput.value;
         scaleInput.value = scale.toString();
         scaleValue.textContent = String(1 << parseInt(scaleInput.value));
         const pattern = new Array(tileHeight);

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,11 +36,11 @@
       </div>
       <div class="row">
         <input type="range" id="tileWidth" value="66" min="2" max="129" style="width: 200px" />
-        <label for="tileWidth">Width: <span id="tileWidth-value">66</span></label>
+        <label for="tileWidth">Width: <input type="number" min="2" max="129" id="tileWidth-value" value=66></input></label>
       </div>
       <div class="row">
         <input type="range" id="tileHeight" value="10" min="2" max="65" style="width: 200px" />
-        <label for="tileHeight">Height: <span id="tileHeight-value">10</span></label>
+        <label for="tileHeight">Height: <input type="number" min="2" max="129" id="tileHeight-value" value=10></input></label>
       </div>
       <div class="row">
         <input type="range" id="scale" value="1" min="0" max="7" style="width: 200px" />

--- a/src/app.ts
+++ b/src/app.ts
@@ -113,13 +113,13 @@ document.addEventListener("DOMContentLoaded", () => {
   ) as HTMLInputElement;
   const tileWidthValue = document.getElementById(
     "tileWidth-value"
-  ) as HTMLSpanElement;
+  ) as HTMLInputElement;
   const tileHeightInput = document.getElementById(
     "tileHeight"
   ) as HTMLInputElement;
   const tileHeightValue = document.getElementById(
     "tileHeight-value"
-  ) as HTMLSpanElement;
+  ) as HTMLInputElement;
   const scaleInput = document.getElementById("scale") as HTMLInputElement;
   const scaleValue = document.getElementById("scale-value") as HTMLSpanElement;
   const clearGridBtn = document.getElementById(
@@ -317,11 +317,19 @@ document.addEventListener("DOMContentLoaded", () => {
   };
 
   tileWidthInput.addEventListener("input", () => {
-    tileWidthValue.textContent = tileWidthInput.value;
+    tileWidthValue.value = tileWidthInput.value;
     generateGrid();
   });
   tileHeightInput.addEventListener("input", () => {
-    tileHeightValue.textContent = tileHeightInput.value;
+    tileHeightValue.value = tileHeightInput.value;
+    generateGrid();
+  });
+  tileWidthValue.addEventListener("input", () => {
+    tileWidthInput.value = tileWidthValue.value;
+    generateGrid();
+  });
+  tileHeightValue.addEventListener("input", () => {
+    tileHeightInput.value = tileHeightValue.value;
     generateGrid();
   });
   scaleInput.addEventListener("input", () => {
@@ -891,8 +899,8 @@ document.addEventListener("DOMContentLoaded", () => {
     const scale = decoder.getScale();
     tileWidthInput.value = tileWidth.toString();
     tileHeightInput.value = tileHeight.toString();
-    tileWidthValue.textContent = tileWidthInput.value;
-    tileHeightValue.textContent = tileHeightInput.value;
+    tileWidthValue.value = tileWidthInput.value;
+    tileHeightValue.value = tileHeightInput.value;
     scaleInput.value = scale.toString();
     scaleValue.textContent = String(1 << parseInt(scaleInput.value));
     const pattern: number[][] = new Array(tileHeight);


### PR DESCRIPTION
Now its possible to change the width/height either with the arrow keys or by changing the value directly. The slider obviously still works. I was always bothered by needing to move my mouse by like one pixel just to get the number right, so I made this :)
The canvas also automatically updates just like how it updates when changing the slider.

<img width="358" height="59" alt="image" src="https://github.com/user-attachments/assets/c510b086-ecb9-4166-a35b-618ba7b52796" />
